### PR TITLE
'of' not 'in'

### DIFF
--- a/_en/core.md
+++ b/_en/core.md
@@ -310,7 +310,7 @@ const bound = 3
 
 const clip = (values) => {
   let result = []
-  for (let v in values) {
+  for (let v of values) {
     if (v <= bound) {
       result.push(v)
     }


### PR DESCRIPTION
Fixes #14 

Based on my reading of the example in Core->Modules, I think that this should be `let v of values` not `let v in values`. If I got this right, please merge.