### PR TITLE
Mentioning fat arrow syntax when classes are first introduced.

### DIFF
--- a/_en/core.md
+++ b/_en/core.md
@@ -268,7 +268,7 @@ limits of 3,apple,sub-array are 3,3
 - Generally don't write functions this way any longer
   - Interacts in odd ways with other features of the language
   - [Section on legacy issues](../legacy/#prototypes) explains why in more detail
-- Instead, use [fat arrow functions](#g:far-arrow-function)
+- Instead, use [fat arrow functions](#g:fat-arrow)
   - Parameter list, `=>`, and body creates a function without a name
   - Assign that to a constant or variable
 

--- a/_en/gloss.md
+++ b/_en/gloss.md
@@ -136,7 +136,7 @@ We say that the new class [inherits](#g:inherit) from the old one.
 a horrible neologism meaning "equivalent to false".
 See also the equally horrible [truthy](#g:truthy).
 
-**fat arrow function**{:#g:far-arrow-function}:
+**fat arrow function**{:#g:fat-arrow}:
 a JavaScript function defined using the syntax `(...parameters...) => {...body...}`.
 Fat arrow functions treat the special value `this` in a less inconsistent way
 than their older equivalents.

--- a/_en/oop.md
+++ b/_en/oop.md
@@ -98,7 +98,7 @@ rectangle: area 6 perimeter 10
   - Which turned out to be [clumsy and confusing](../legacy/#prototypes)
 - Most object-oriented languages use [classes](#g:class)
   - These have been added to JavaScript ES6
-  - We will only use them
+  - We will use them instead of prototypes throughout
 
 ```js
 class Square {
@@ -124,7 +124,9 @@ sq name square and area 9
   - Calls `constructor` to initialize the object's state
   - Class names are written in CamelCase by convention
 - `this` is a pronoun that refers to a single specific object
-- Methods are defined with a slightly different syntax than the fat arrows we have been using
+- Methods are defined with classic syntax rather than the [fat arrows](#g:fat-arrow) we have been using
+  - It is what current version of Node prefer
+  - We will explore this topic further in the [discussion of visualization](../vis/)
 - Again, supports polymorphism
 
 ```js

--- a/_en/vis.md
+++ b/_en/vis.md
@@ -286,7 +286,7 @@ const vegaEmbed = require('vega-embed')
 - This is where we trip over something that's still painful in 2018
   - Old method of getting libraries is `require`, and that's still what Node supports as of Version 10.9.0
   - New standard is `import`
-  - Allows a module to define a default value so that `import 'something'` gets a function a class, or whatever
+  - Allows a module to define a default value so that `import 'something'` gets a function, a class, or whatever
   - Which is really handy, but `require` doesn't work that way
 - Using Node on the command, we can:
   - Add the `--experimental-modules` flag


### PR DESCRIPTION
- Defer real discussion until it's needed because Node still prefers old-style function syntax.
- Fix label of glossary entry for fat arrow stuff (was "far arrow").

Closes #27.