### PR TITLE
Adding title attribute to existing images.

### DIFF
--- a/_en/htmlcss.md
+++ b/_en/htmlcss.md
@@ -19,7 +19,7 @@ keypoints:
 - "Use `ul` and `ol` for unordered and ordered lists, and `li` for list elements."
 - "Use `table` for tables, `tr` for rows, `th` for headings, and `td` for regular data."
 - "Use `<a href=\"...\">...</a>` to create links."
-- "Use `<img src=\"...\" alt=\"...\" />` to include images."
+- "Use `<img src=\"...\" title=\"...\" alt=\"...\" />` to include images."
 - "Use CSS to define appearance of elements."
 - "Use `class` and `id` to identify elements."
 - "Use selectors to specify the elements that CSS applies to."
@@ -335,12 +335,13 @@ and refer to that file using an `img` element
 The `src` attribute of the `img` tag specifies where to find the file;
 as with the `href` attribute of an `a` element,
 this can be either a URL or a local path.
-Every `img` should also include an `alt` attribute
-with some descriptive text to aid accessibility and search engines.
+Every `img` should also include a `title` attribute (whose purpose is self-explanatory)
+and an `alt` attribute with some descriptive text to aid accessibility and search engines.
 
 ```html
-<img src="./html5.png" alt="HTML5 Logo with local path"/>
-<img src="https://github.com/software-tools-in-javascript/js-vs-rc/blob/master/src/htmlcss/html5.png" alt="HTML5 logo online"/>
+<img src="./html5.png" title="HTML5 Logo" alt="Displays the HTML5 logo using a local path" />
+<img src="https://github.com/software-tools-in-javascript/js-vs-rc/blob/master/src/htmlcss/html5.png"
+     title="HTML5 Logo" alt="Display the HTML5 logo using a URL" />
 ```
 {: title="src/htmlcss/images.html"}
 

--- a/_en/vis.md
+++ b/_en/vis.md
@@ -122,7 +122,7 @@ and feel very proud of ourselves.
 
 <figure>
   <figcaption>Mark and Encoding</figcaption>
-  <img id="f:vis-vega-mark-encoding" src="../../files/vega-mark-encoding.png" alt="Mark and Encoding" />
+  <img id="f:vis-vega-mark-encoding" src="../../files/vega-mark-encoding.png" title="Mark and Encoding" />
 </figure>
 
 There are also some poorly-styled links for various controls that we're not going to use.
@@ -151,7 +151,7 @@ We now have the visualization we wanted:
 
 <figure>
   <figcaption>Without Controls</figcaption>
-  <img id="f:vis-vega-disable-controls" src="../../files/vega-disable-controls.png" alt="Without Controls" />
+  <img id="f:vis-vega-disable-controls" src="../../files/vega-disable-controls.png" title="Without Controls" />
 </figure>
 
 Vega-Lite has a *lot* of options:
@@ -196,7 +196,7 @@ which is set to `"average"`:
 
 <figure>
   <figcaption>Aggregating and Using Points</figcaption>
-  <img id="f:vis-vega-aggregate-points" src="../../files/vega-aggregate-points.png" alt="Aggregating and Using Points" />
+  <img id="f:vis-vega-aggregate-points" src="../../files/vega-aggregate-points.png" title="Aggregating and Using Points" />
 </figure>
 
 ## Local Installation {#s:vis-vega-local}

--- a/_en/vis.md
+++ b/_en/vis.md
@@ -122,7 +122,7 @@ and feel very proud of ourselves.
 
 <figure>
   <figcaption>Mark and Encoding</figcaption>
-  <img id="f:vis-vega-mark-encoding" src="../../files/vega-mark-encoding.png" title="Mark and Encoding" />
+  <img id="f:vis-vega-mark-encoding" src="../../files/vega-mark-encoding.png" />
 </figure>
 
 There are also some poorly-styled links for various controls that we're not going to use.
@@ -151,7 +151,7 @@ We now have the visualization we wanted:
 
 <figure>
   <figcaption>Without Controls</figcaption>
-  <img id="f:vis-vega-disable-controls" src="../../files/vega-disable-controls.png" title="Without Controls" />
+  <img id="f:vis-vega-disable-controls" src="../../files/vega-disable-controls.png" />
 </figure>
 
 Vega-Lite has a *lot* of options:
@@ -196,7 +196,7 @@ which is set to `"average"`:
 
 <figure>
   <figcaption>Aggregating and Using Points</figcaption>
-  <img id="f:vis-vega-aggregate-points" src="../../files/vega-aggregate-points.png" title="Aggregating and Using Points" />
+  <img id="f:vis-vega-aggregate-points" src="../../files/vega-aggregate-points.png" />
 </figure>
 
 ## Local Installation {#s:vis-vega-local}

--- a/_en/vis.md
+++ b/_en/vis.md
@@ -120,9 +120,9 @@ When we open the page now,
 we see a bar chart,
 and feel very proud of ourselves.
 
-<figure>
+<figure id="f:vis-vega-mark-encoding">
   <figcaption>Mark and Encoding</figcaption>
-  <img id="f:vis-vega-mark-encoding" src="../../files/vega-mark-encoding.png" />
+  <img src="../../files/vega-mark-encoding.png" />
 </figure>
 
 There are also some poorly-styled links for various controls that we're not going to use.
@@ -149,9 +149,9 @@ We can fill in the options argument to `vegaEmbed` to turn those off:
 
 We now have the visualization we wanted:
 
-<figure>
+<figure id="f:vis-vega-disable-controls">
   <figcaption>Without Controls</figcaption>
-  <img id="f:vis-vega-disable-controls" src="../../files/vega-disable-controls.png" />
+  <img src="../../files/vega-disable-controls.png" />
 </figure>
 
 Vega-Lite has a *lot* of options:
@@ -194,9 +194,9 @@ which is set to `"average"`:
 ```
 {: title="src/viz/vega-aggregate-points.html"}
 
-<figure>
+<figure id="f:vis-vega-aggregate-points">
   <figcaption>Aggregating and Using Points</figcaption>
-  <img id="f:vis-vega-aggregate-points" src="../../files/vega-aggregate-points.png" />
+  <img src="../../files/vega-aggregate-points.png" />
 </figure>
 
 ## Local Installation {#s:vis-vega-local}

--- a/src/htmlcss/images.html
+++ b/src/htmlcss/images.html
@@ -1,6 +1,7 @@
 <html>
   <body>
-    <img src="./html5.png" alt="HTML5 Logo with local path"/>
-    <img src="https://github.com/gvwilson/js-vs-rc/blob/master/src/htmlcss/html5.png" alt="HTML5 logo online"/>
+    <img src="./html5.png" title="HTML5 Logo" alt="Displays the HTML5 logo using a local path" />
+    <img src="https://github.com/software-tools-in-javascript/js-vs-rc/blob/master/src/htmlcss/html5.png"
+         title="HTML5 Logo" alt="Display the HTML5 logo using a URL" />
   </body>
 </html>


### PR DESCRIPTION
Guideline is:

1.  Use `title` for the image title.
2.  Use `alt` for alternative descriptive text to be read aloud or displayed if the image is missing.