### PR TITLE
Removing special link fixup

### DIFF
--- a/_en/capstone.md
+++ b/_en/capstone.md
@@ -102,7 +102,7 @@ we'll be able to send database queries to `dataManager`.
 This variable is global within this file,
 but since it's not exported,
 it's invisible outside.
-Variables like this are called [module variables](#g:module-variable),
+Variables like this are called [module variables](../gloss/#g:module-variable),
 and give us a way to share information among the functions in a module
 without giving anything outside the module a way to cause (direct) harm to that information.
 

--- a/_en/intro.md
+++ b/_en/intro.md
@@ -15,7 +15,7 @@ keypoints:
 
 ## Who You Are {#s:intro-personas}
 
-Every lesson should aim to [meet the needs of specific learners][t3-process] [Wils2018](#b).
+Every lesson should aim to [meet the needs of specific learners][t3-process] [[Wils2018](../bib/#Wilson2018)].
 The three people described below define the intended audience for this one.
 
 Bhadra

--- a/js/youbou.js
+++ b/js/youbou.js
@@ -19,38 +19,9 @@ const stripeTables = () => {
   })
 }
 
-// Patch bibliography and glossary links.
-const fixSpecialLinks = (prefix) => {
-  const links = document.querySelectorAll('a')
-  Array.from(document.querySelectorAll('a')).forEach(a => {
-    const target = a.getAttribute('href')
-
-    // Bibliography citations: [Abc123,Def456](#b:) in Markdown
-    if (target === '#b:') {
-      const replacement = document.createElement('span')
-      const references = a.textContent
-            .split(',')
-            .map(s => s.trim())
-            .map(s => `<a class="bibref" href="${prefix}/bib/#${s}">${s}</a>`)
-            .join(',')
-      replacement.innerHTML = `[${references}]`
-      a.parentNode.replaceChild(replacement, a)
-    }
-
-    // Glossary entry: [text](#g:key) in Markdown
-    else if (target.startsWith('#g:')) {
-      a.setAttribute('href', prefix + '/gloss/' + target)
-      a.classList.add('glossref')
-    }
-  })
-}
-
 // Perform transformations on load (which is why this script is included at the
 // bottom of the page).
 (function(){
-  const pageIsRoot = (document.currentScript.getAttribute('ROOT') != '')
-  const prefix = pageIsRoot ? '.' : '..'
   makeTableOfContents()
   stripeTables()
-  fixSpecialLinks(prefix)
 })()


### PR DESCRIPTION
- Remove JavaScript that handles bibliography and glossary links after page load.
- Tidy up sole uses of these special links.