### PR TITLE
Fix typo in Basic Features section

### DIFF
--- a/_en/basics.md
+++ b/_en/basics.md
@@ -311,7 +311,7 @@ const creature = {
 ```
 
 `[object Object]` is not particularly useful output when we want to see what an object contains.
-To get a ore helpful string representation,
+To get a more helpful string representation,
 use `JSON.stringify(object)`:
 
 ```js


### PR DESCRIPTION
Found a typo while reading through the Basics. Thought I'd make a pull request to help :smiley: