### PR TITLE
Revert "remove unused TitledField component from capstone"

### DIFF
--- a/src/capstone/front/TitledField.js
+++ b/src/capstone/front/TitledField.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const TitledField = ({label, value, onChange}) => {
+  return (
+    <span>
+      {label}: <input type="text" value={value} onChange={(e) => onChange(e.target.value)} />
+    </span>
+  )
+}
+
+export default TitledField


### PR DESCRIPTION
Apparently, in December, I thought that `TitledField` doesn't get used in the capstone. But clearly it does, so this brings it back.

This reverts commit b851ddd6f7a9fa29f3ab0f162912461478e59ca8.