### PR TITLE
Add including links.md reference to new pages

### DIFF
--- a/_en/deploy.md
+++ b/_en/deploy.md
@@ -71,3 +71,5 @@ if it doesn't receive any requests for 5 minutes,
 the virtual machine is put to sleep.
 It is automatically restarted the next time a request comes in,
 but there will be a lag as it wakes up.
+
+{% include links.md %}

--- a/_en/extensible.md
+++ b/_en/extensible.md
@@ -69,3 +69,5 @@ we can provide a [protocol](#g:protocol) for plugins
 so that people can add new functionality without rewriting what's already there.
 Each plugin must have an [entry point](#g:entry-point) like the function `page`
 so that the framework knows where to start.
+
+{% include links.md %}


### PR DESCRIPTION
I found the Glitch link on the deployment page broken and discovered it missing the `links.md` includes near the bottom like the rest of the pages. 

So I added the necessary reference to the deployment page which was necessary, but I've also added it to the extensible page as well for consistency. Let me know if the second one was unnecessary and I can make a quick fix to remove it.