### PR TITLE
Fixes two minor issues with basics.md

### DIFF
--- a/_en/basics.md
+++ b/_en/basics.md
@@ -187,14 +187,14 @@ for (let pair of values) {
 ```
 {: title="basics/control-flow.js"}
 ```text
-0 of type number is falsy
-1 of type number is truthy
+0 'of type' 'number' 'is falsy'
+1 'of type' 'number' 'is truthy'
  of type string is falsy
 text of type string is truthy
-undefined of type undefined is falsy
-null of type object is falsy
- of type object is truthy
-2,3 of type object is truthy
+undefined 'of type' 'undefined' 'is falsy'
+null 'of type' 'object' 'is falsy'
+[] 'of type' 'object' 'is truthy'
+[ 2, 3 ] 'of type' 'object' 'is truthy'
 ```
 
 This example shows that arrays are [heterogeneous](#g:heterogeneous),

--- a/_en/basics.md
+++ b/_en/basics.md
@@ -153,7 +153,7 @@ put values separated by commas inside `[]` to create an [array](#g:array),
 and use `for...of` to loop over the values in that array.
 Note that we use `let` rather than the older `var` and `of` and not `in`:
 the latter returns the indexes of the collection (e.g., 0, 1, 2),
-which has some traps for the unwary ((s:legacy-iteration)[#REF)).
+which has some traps for the unwary ([s:legacy-iteration](#REF)).
 Note also that indexing starts from 0 rather than 1,
 and that indentation is optional and for readability purposes only.
 This may be different from the language that you're used to.


### PR DESCRIPTION
1 - minor jekyll link formatting error that was preventing a link from rendering properly
2 - some output was not representative of the output actually received
    This was mainly due to a lack of square brackets in the output, but the original output also lacked numerous quotation marks